### PR TITLE
Add package.json to enable npm installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "signalr",
+    "version": "2.2.1",
+    "description": "Microsoft ASP.NET SignalR JavaScript Client",
+    "main": "jquery.signalR.js",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/signalr/bower-signalr.git"
+    },
+    "keywords": [
+        "signalr",
+        "microsoft",
+        "asp.net",
+        "javascript",
+        "jquery",
+        "realtime"
+    ],
+    "author": "Microsoft",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/signalr/bower-signalr/issues"
+    },
+    "homepage": "https://github.com/signalr/bower-signalr#readme",
+    "dependencies": {
+        "jquery": ">=1.6.4"
+    }
+}


### PR DESCRIPTION
Refer to PR https://github.com/SignalR/bower-signalr/pull/2 for more info on this. By adding a `package.json` file to the repository, npm can be supported.
