### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,6 @@ node_modules
 
 #Exclude npm packages
 *.tgz
+
+#Exclude bower.json from npm package
+bower.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+
+#Exclude npm packages
+*.tgz


### PR DESCRIPTION
@moozzyk, now that this package is also used for npm, it's good to have an _.npmignore_ file as otherwise _.gitignore_ is renamed during the packing/publishing process. It appears that the build directory was not entirely clean when 2.2.2 was built as it contained the tarball zip for 2.2.1. The _.npmignore_ in this PR addresses that going forward.

![image](https://user-images.githubusercontent.com/8005145/27553101-a594f7e0-5a77-11e7-846a-f4d735dcaf49.png)
