### PR TITLE
updates to package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **NOTE**: The Bower package for SignalR is now deprecated, since Bower itself is now deprecated. Please consider migrating to Yarn or NPM (as recommended [by the bower team](https://bower.io/blog/2017/how-to-migrate-away-from-bower/))
 
-This is the client for ASP.NET SignalR. Use this package if you are connecting to an application written in ASP.NET (using System.Web, or OWIN self-host). This package is **not compatible** with ASP.NET **Core** SignalR. If you are connecting to an ASP.NET Core application, use the `@aspnet/signalr` package.
+This is the client for ASP.NET SignalR. Use this package if you are connecting to an application written in ASP.NET (using System.Web, or OWIN self-host). This package is **not compatible** with ASP.NET **Core** SignalR. If you are connecting to an ASP.NET Core application, use the `@microsoft/signalr` package.
 
 ## Documentation
 


### PR DESCRIPTION
needed to update this readme even though the repo is read-only now, as this readme.md is used by the SignalR client on NPM and we need to direct customers to the right NEW spot.